### PR TITLE
Ignore approved PRs when finding review required

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,9 +2,9 @@ const me = document.querySelector('summary[aria-label="View profile and more"] i
 
 [].forEach.call(document.querySelectorAll('.js-issue-row'), row => {
   const isPR = !!row.querySelector('[aria-label="Open pull request"]');
-  const reviewRequired = !!row.querySelector('[aria-label="Review required before merging"]');
   const approved = (row.querySelector('a.muted-link.tooltipped') || {}).innerText === 'Approved';
   const changesRequested = (row.querySelector('a.muted-link.tooltipped') || {}).innerText === 'Changes requested';
+  const reviewRequired = !(approved || changesRequested);
   const assignee = (row.querySelector('.from-avatar') || {alt: ''}).alt.slice(1);
   const author = (row.querySelector('.opened-by .muted-link') || {}).innerText;
   const title = (row.querySelector('.link-gray-dark.h4') || {}).innerText;
@@ -22,7 +22,7 @@ const me = document.querySelector('summary[aria-label="View profile and more"] i
     highlight = true;
   }
 
-  if(!failsTravis && isPR && !changesRequested && author !== me && (assignee === me || assignee === '')) {
+  if(!failsTravis && isPR && reviewRequired && author !== me && (assignee === me || assignee === '')) {
     highlight = true;
   }
 


### PR DESCRIPTION
When updating the check for 'review required' to not look for the string
'review required' specifically, I erroneously only negated the 'changes
requested' check. Of course, there are three states, not two, a PR can
have, so Approved PRs that were still building on Travis were
highlighted as yellow now.

Surely we will never find a fourth forgotten state as well.