### PR TITLE
Remove hack for highlighting 5/6 passes on backend

### DIFF
--- a/content.js
+++ b/content.js
@@ -10,12 +10,8 @@ function colorizePullRequests() {
     const author = (row.querySelector('.opened-by .muted-link') || {}).innerText;
     const title = (row.querySelector('.link-gray-dark.h4') || {}).innerText;
     const isDjangoBackend = row.querySelector('.float-left.col-9.lh-condensed.p-2 a.muted-link').href === 'https://github.com/HyreAS/django-backend';
-    const failsTravis = isDjangoBackend
-      ? row.querySelector('.commit-build-statuses a.tooltipped').getAttribute('aria-label') !== '5 / 6 checks OK' && !!row.querySelector('.commit-build-statuses .text-red')
-      : !!row.querySelector('.commit-build-statuses .text-red');
-    const passesTravis = isDjangoBackend
-      ? row.querySelector('.commit-build-statuses a.tooltipped').getAttribute('aria-label') === '5 / 6 checks OK' || !!row.querySelector('.commit-build-statuses .text-green')
-      : !!row.querySelector('.commit-build-statuses .text-green');
+    const failsTravis = !!row.querySelector('.commit-build-statuses .text-red');
+    const passesTravis = !!row.querySelector('.commit-build-statuses .text-green');
     const priorityLowLabel = row.querySelector('.labels a[title="Priority: Low"]');
 
 


### PR DESCRIPTION
We added a hack to highlight PRs where only 5/6 build jobs had passed in
order to still highlight PRs where the coverage check had caused the PR
to get a red build status. A while after this, we changed those failure
states to neutral, which means this hack should no longer be needed. And
now this hack only causes PRs to become highlighted when one of the test
or lint jobs fail, which means they should in fact not be highlighted.