### PR TITLE
Remove isDjangoBackend check

### DIFF
--- a/content.js
+++ b/content.js
@@ -10,7 +10,6 @@ function colorizePullRequests() {
     const assignee = (row.querySelector('.from-avatar') || {alt: ''}).alt.slice(1);
     const author = (row.querySelector('.opened-by .muted-link') || {}).innerText;
     const title = (row.querySelector('.link-gray-dark.h4') || {}).innerText;
-    const isDjangoBackend = row.querySelector('.float-left.col-9.lh-condensed.p-2 a.muted-link').href === 'https://github.com/HyreAS/django-backend';
     const failsTravis = !!row.querySelector('.commit-build-statuses .text-red');
     const passesTravis = !!row.querySelector('.commit-build-statuses .text-green');
     const priorityLowLabel = row.querySelector('.labels a[title="Priority: Low"]');


### PR DESCRIPTION
We don't use it anymore, and something in the markup didn't exist
anymore, so the querySelector returned null. Had we still needed it, I
would have added a fallback like on the line before it, but this was
just dead code breaking our flow!