### PR TITLE
Update github color names

### DIFF
--- a/content.css
+++ b/content.css
@@ -44,7 +44,7 @@ font-weight: 100 !important;
 }
 
 .github-pull-request-colorizer--dark-mode.github-pull-request-colorizer--highlight .github-pull-request-colorizer--title {
-  color: var(--color-alert-warn-text) !important;
+  color: var(--color-attention-fg) !important;
 }
 .github-pull-request-colorizer--dark-mode.github-pull-request-colorizer--highlight .github-pull-request-colorizer--information-line,
 .github-pull-request-colorizer--dark-mode.github-pull-request-colorizer--highlight .github-pull-request-colorizer--information-line a.muted-link {
@@ -74,7 +74,7 @@ font-weight: 100 !important;
 }
 
 .github-pull-request-colorizer--green-pr {
-  background-image: linear-gradient(45deg, var(--color-alert-success-bg) 25%, #ffffff00 25%, #ffffff00 50%, var(--color-alert-success-bg) 50%, var(--color-alert-success-bg) 75%, #ffffff00 75%, #ffffff00 100%);
+  background-image: linear-gradient(45deg, var(--color-success-subtle) 25%, #ffffff00 25%, #ffffff00 50%, var(--color-success-subtle) 50%, var(--color-success-subtle) 75%, #ffffff00 75%, #ffffff00 100%);
   background-size: calc(56.57px * 2) calc(56.57px * 2);
 }
 
@@ -89,14 +89,12 @@ font-weight: 100 !important;
 }
 
 .github-pull-request-colorizer--highlight {
-  background-color: var(--color-alert-warn-bg) !important;
-  border-top: 1px solid var(--color-alert-warn-border) !important;
-  border-bottom: 1px solid var(--color-alert-warn-border) !important;
+  background-color: var(--color-attention-subtle) !important;
+  border-top: 1px solid var(--color-border-muted) !important;
   transform: translateZ(20px);
 }
 
 .github-pull-request-colorizer--green-pr {
-  border-top: 1px solid var(--color-alert-success-border) !important;
-  border-bottom: 1px solid var(--color-alert-success-border) !important;
+  border-top: 1px solid var(--color-border-muted) !important;
   transform: translateZ(10px);
 }


### PR DESCRIPTION
Looks like github has changed the names of some CSS variables for
colors. This tries to fix the ones I could find, it should look the same
as before in both light mode and dark mode now.