### PR TITLE
Handle deferred content in PR list

### DIFF
--- a/content.js
+++ b/content.js
@@ -97,6 +97,9 @@ function colorizePullRequests() {
       row.classList.add("github-pull-request-colorizer--dark-mode");
     }
 
+    const hasDeferredContent =
+      row.querySelector("batch-deferred-content") !== null;
+
     const approved =
       (row.querySelector("a.Link--muted.tooltipped") || {}).innerText ===
       "Approved";
@@ -202,6 +205,10 @@ function colorizePullRequests() {
       highlight = false;
     }
 
+    if (hasDeferredContent) {
+      highlight = false;
+    }
+
     if (highlight) {
       row.classList.add("github-pull-request-colorizer--highlight");
     }
@@ -210,6 +217,12 @@ function colorizePullRequests() {
       row.classList.add("github-pull-request-colorizer--draft-pr");
     }
   });
+
+  const hasDeferredContent =
+    document.querySelector("batch-deferred-content") !== null;
+  if (hasDeferredContent) {
+    setTimeout(colorizePullRequests, 100);
+  }
 }
 
 try {


### PR DESCRIPTION
GitHub has started loading "review required" / "changes requested"
information asynchronously in the pull request list. This detects the
lazy loaded content, and disables highlighting of rows that still have
deferred content.

A new run of the colorizer is scheduled to run again in 100 ms as long
as deferred content exists.

This should ensure that no row is incorrectly highlighted while loading
and that when all loading is complete, all rows are highlighted
correctly.