### PR TITLE
Properly read username from GitHub metadata

### DIFF
--- a/content.js
+++ b/content.js
@@ -23,11 +23,7 @@ function colorizeAnnotations() {
 }
 
 function colorizePullRequests() {
-  const me = document
-    .querySelector(
-      ':is(.AppHeader-user, summary[aria-label="View profile and more"]) img.avatar'
-    )
-    .alt.slice(1);
+  const me = document.querySelector('meta[name="user-login"]').content;
 
   const colorMode = document.querySelector("html").dataset.colorMode;
   let darkMode = false;


### PR DESCRIPTION
Turns out GitHub stores lots of useful information in meta tags!

This is a follow-up from 162b34a5fb7c613bcc944b29610ac583edff7a0a, which actually make the colorizer fully work with the new layout. The previous commit just fixed a crash making it not 100% broken, but this commit ensures that PRs you're assigned to properly get yellow when they require your action!