### PR TITLE
Stop breaking layout of repo issue/pr views

### DIFF
--- a/content.css
+++ b/content.css
@@ -22,7 +22,7 @@ a.github-pull-request-colorizer--repository {
   font-weight: 100 !important;
 }
 
-.github-pull-request-colorizer--information-line {
+.github-pull-request-colorizer--multi-repo .github-pull-request-colorizer--information-line {
   margin-left: 192px;
 }
 
@@ -61,7 +61,7 @@ a.github-pull-request-colorizer--repository {
   fill: #24292e;
 }
 
-.github-pull-request-colorizer--build-status-parent {
+.github-pull-request-colorizer--multi-repo .github-pull-request-colorizer--build-status-parent {
   position: absolute;
   left: 176px;
   top: 9px;

--- a/content.js
+++ b/content.js
@@ -24,6 +24,10 @@ function colorizeAnnotations() {
 
 function colorizePullRequests() {
   const me = document.querySelector('meta[name="user-login"]').content;
+  const isMultiRepoView =
+    document
+      .querySelector('meta[name="selected-link"]')
+      .getAttribute("value") === "/pulls";
 
   const colorMode = document.querySelector("html").dataset.colorMode;
   let darkMode = false;
@@ -47,6 +51,9 @@ function colorizePullRequests() {
     row.classList.add("github-pull-request-colorizer--row");
     if (darkMode) {
       row.classList.add("github-pull-request-colorizer--dark-mode");
+    }
+    if (isMultiRepoView) {
+      row.classList.add("github-pull-request-colorizer--multi-repo");
     }
 
     const hasDeferredContent =
@@ -80,9 +87,6 @@ function colorizePullRequests() {
     const informationLineElement = row.querySelector("span.opened-by");
     const titleElement = row.querySelector(".Link--primary.h4");
     const PRIconElement = row.querySelector("div.flex-shrink-0.pt-2.pl-3");
-    const repoFullName = (
-      repositoryElement ? repositoryElement.innerText : ""
-    ).trim();
     const buildStatusElement = row.querySelector(".commit-build-statuses");
 
     if (repositoryElement) {
@@ -97,7 +101,7 @@ function colorizePullRequests() {
         "github-pull-request-colorizer--information-line"
       );
     }
-    if (PRIconElement) {
+    if (isMultiRepoView && PRIconElement) {
       PRIconElement.style.display = "none";
     }
 


### PR DESCRIPTION
This plugin includes some custom styling to override the look of PRs in a list, mainly to make the repo name take up less place when browsing PRs for more than one repo at once. This has forever been breaking the layout of a lot of other views in GitHub. With this bit of extra logic to check what page we're actually on, we can stop breaking the layout on all those other pages!