### PR TITLE
Resize the clock for "updated-at"

### DIFF
--- a/content.js
+++ b/content.js
@@ -172,7 +172,14 @@ function colorizePullRequests() {
     if (isDraftPR) {
       row.classList.add("github-pull-request-colorizer--draft-pr");
     }
+
+    const updatedClock = row.querySelector(".octicon-clock")
+    if (updatedClock) {
+      updatedClock.style.width = "12px";
+      updatedClock.style.paddingBottom = "2px";
+    }
   });
+
 
   const hasDeferredContent =
     document.querySelector("batch-deferred-content") !== null;

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,8 @@
 {
   "manifest_version": 2,
-
   "name": "GitHub Pull Request Colorizer",
   "description": "This extension colorizes pull request listings.",
-  "version": "1.13.0",
+  "version": "1.15.0",
   "icons": {
     "32": "icon.png"
   },


### PR DESCRIPTION
Before:
<pre align="center"><img width="200" alt src="https://github.com/sigvef/github-pull-request-colorizer/assets/5347151/7831df3c-80a4-47c0-8f5f-67b017b7b5fb" /></pre>

After:
<pre align="center"><img width="200" alt src="https://github.com/sigvef/github-pull-request-colorizer/assets/5347151/a6dc5487-def3-419c-83ab-49f684391475" /></pre>


Also bumped the version number directly to 1.15.0, because I believe
1.14.0 might be burned by @stiaje?
