### PR TITLE
Repair listing multi-repo view

### DIFF
--- a/content.css
+++ b/content.css
@@ -59,13 +59,6 @@ a.github-pull-request-colorizer--repository {
   border-bottom-width: 1px;
 }
 
-.github-pull-request-colorizer--multi-repo
-  .github-pull-request-colorizer--build-status-parent {
-  position: absolute;
-  left: 176px;
-  top: 9px;
-}
-
 .github-pull-request-colorizer--highlight {
   background-color: var(--bgColor-attention-muted) !important;
   border-top: 1px solid var(--borderColor-muted) !important;

--- a/content.js
+++ b/content.js
@@ -87,7 +87,6 @@ function colorizePullRequests() {
     const informationLineElement = row.querySelector("span.opened-by");
     const titleElement = row.querySelector(".Link--primary.h4");
     const PRIconElement = row.querySelector("div.flex-shrink-0.pt-2.pl-3");
-    const buildStatusElement = row.querySelector(".commit-build-statuses");
 
     if (repositoryElement) {
       const name = repositoryElement.innerText;
@@ -107,15 +106,6 @@ function colorizePullRequests() {
 
     if (titleElement) {
       titleElement.classList.add("github-pull-request-colorizer--title");
-    }
-
-    if (buildStatusElement) {
-      const parent = buildStatusElement.parentElement;
-      if (parent) {
-        parent.classList.add(
-          "github-pull-request-colorizer--build-status-parent"
-        );
-      }
     }
 
     let highlight = false;
@@ -173,13 +163,12 @@ function colorizePullRequests() {
       row.classList.add("github-pull-request-colorizer--draft-pr");
     }
 
-    const updatedClock = row.querySelector(".octicon-clock")
+    const updatedClock = row.querySelector(".octicon-clock");
     if (updatedClock) {
       updatedClock.style.width = "12px";
       updatedClock.style.paddingBottom = "2px";
     }
   });
-
 
   const hasDeferredContent =
     document.querySelector("batch-deferred-content") !== null;


### PR DESCRIPTION
I think GitHub must have changed the markup surrounding the build status so it's now directly under the parent list element.

With the current markup, I can't see that anything looks broken now that still needs fixing around the status element, so I think we can just remove this.